### PR TITLE
Add Unique Mode

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -32,6 +32,18 @@ https://example.com/pathtwo?one=1newval&two=2newval
 https://example.net/a/path?one=1newval&two=2newval
 ```
 
+### Modify Query String Values one at a time
+
+```
+▶ cat urls.txt | qsreplace -u newval
+https://example.com/path?one=newval&two=2
+https://example.com/path?one=1&two=newval
+https://example.com/pathtwo?one=1&two=newval
+https://example.com/pathtwo?one=newval&two=2
+https://example.net/a/path?one=1&two=newval
+https://example.net/a/path?one=newval&two=2
+```
+
 ### Remove Duplicate URL and Parameter Combinations
 
 You can omit the argument to `-a` to only output each combination of URL and query string parameters once:


### PR DESCRIPTION
Unique Mode was added to qsreplace to allow modifying the value of parameters one at a time, rather than updating all values at once. 

This is useful in scenarios where validation is applied to some parameters, but not all. Injecting a payload iteratively into each parameter value allows for finer control on bypassing validations and troubleshooting which parameters are subject to injection attacks. The trade-off is path explosion for requests with a large number of parameters. 

The readme was updated to include a sample usage. The unique mode works in combination with append mode if both flags are set. 